### PR TITLE
Reset properties

### DIFF
--- a/src/jsonconfig.cpp
+++ b/src/jsonconfig.cpp
@@ -250,6 +250,19 @@ QVariant JsonConfig::getProperty(const QString &layer, const QString &key)
     return {};
 }
 
+void JsonConfig::resetProperty(const QString & layer, const QString & key)
+{
+    int propIdx = -1;
+    Node * n = m_root.getNode(key, &propIdx);
+    auto l = getLayer(layer);
+    if (!l) {    
+        return;
+    }
+    if (propIdx != -1 && l->index > 0) {
+        n->removeProperty(propIdx, l->index);
+    }
+}
+
 void JsonConfig::beginUpdate()
 {
     m_deferChangeSignals = true;

--- a/src/jsonconfig.h
+++ b/src/jsonconfig.h
@@ -74,6 +74,7 @@ public slots:
     void clear();
     void setProperty(const QString &layer, const QString &key, const QVariant &value);
     QVariant getProperty(const QString &layer, const QString &key);
+    void resetProperty(const QString & layer, const QString & key);
 
     void beginUpdate();
     void endUpdate();


### PR DESCRIPTION
When we have several config layers . We set some value to 1st layer then we set value by the same key to 2nd config layer. Then we do not want to save value from 2nd layer to file and do some reset and assume that in app  would be value from 1st layer. Now we can do reset bu set value using setProperty but this method does not remove property from  property stack (as expected)  and when we will save layers to file we will have values and in 1st and 2nd configs. I suggest have possibility remove property from particular layer  that will lead to saving layer without  removed property.