### PR TITLE
Fix null pointer reference

### DIFF
--- a/src/jsonconfig.cpp
+++ b/src/jsonconfig.cpp
@@ -151,7 +151,7 @@ QString JsonConfig::loadLayer(const QString &path, QString name, int desiredInde
 {
     auto it = doLoadLayer(path, name, desiredIndex);
     scheduleUpdate();
-    return it->name;
+    return it ? it->name : "";
 }
 
 void JsonConfig::writeConfig(const QString &path, const QString &layer)


### PR DESCRIPTION
if loading layer is finished with error (unread/absent file or bad json structure) this behavior leads to crash.