### PR TITLE
Allow to configure install paths when using as 3rd-party

### DIFF
--- a/ConfigEngine.qbs
+++ b/ConfigEngine.qbs
@@ -1,6 +1,9 @@
 import qbs
 
 Project {
+    property string installImportsDir
+    property string installContentsPath: 'usr/local/'
+
     references: [
         'example/example.qbs',
         'src/plugin.qbs'

--- a/src/plugin.qbs
+++ b/src/plugin.qbs
@@ -1,4 +1,4 @@
-import qbs
+import qbs.FileInfo
 
 DynamicLibrary {
     Depends { name: 'bundle' }
@@ -24,11 +24,13 @@ DynamicLibrary {
     Group {
         files: 'qmldir'
         qbs.install: true
-        qbs.installDir: 'r0mko/config'
+        qbs.installPrefix: project.installContentsPath
+        qbs.installDir: FileInfo.joinPaths(project.installImportsDir, 'r0mko/config')
     }
 
     bundle.isBundle: false
 
     install: true
-    installDir: 'r0mko/config'
+    installDir: FileInfo.joinPaths(project.installImportsDir, 'r0mko/config')
+    qbs.installPrefix: project.installContentsPath
 }

--- a/src/private/node.cpp
+++ b/src/private/node.cpp
@@ -252,7 +252,7 @@ QJsonObject Node::toJsonObject(int level) const // NOLINT
             }
         }
     }
-    for (const auto n : m_childNodes) {
+    for (const auto & n : m_childNodes) {
         // unrolling recursion to iteration makes code less readable. Recursion depth is limited.
         QJsonObject obj = n->toJsonObject(level); // NOLINT
         if (!obj.isEmpty()) {


### PR DESCRIPTION
In other projects, it then can be used like this (example is for macOS):

```qml
Project {
    // …
    SubProject {
        filePath: '3rdParty/ConfigEngine/ConfigEngine.qbs'
        Properties {
            installContentsPath: 'MyMegaTool.app/Contents'
            installImportsDir: 'Imports'
        }
    }
    // …
}
```