### PR TITLE
Don't build an example by default

### DIFF
--- a/example/example.qbs
+++ b/example/example.qbs
@@ -20,4 +20,6 @@ CppApplication {
     bundle.isBundle: false
 
     install: true
+
+    builtByDefault: false
 }


### PR DESCRIPTION
This is to avoid building (and installation) of the example when using as a 3rd-party.