### PR TITLE
Json pointers

### DIFF
--- a/example/fontconfig.json
+++ b/example/fontconfig.json
@@ -3,19 +3,19 @@
         "name": "sansRomanDemi",
         "$type": "FontInfo",
         "family": "Sans_Roman_demi_global",
-        "size": 10,
+        "size": 10
     },
     "sansRomanNormal": {
         "name": "sansRomanNormal",
         "$type": "FontInfo",
         "family": "Sans_Roman_normal_global",
-        "size": 10,
+        "size": 10
     },
     "sansRomanLight": {
         "name": "sansRomanLight",
         "$type": "FontInfo",
         "family": "Sans_Roman_light_global",
-        "size": 10,
+        "size": 10
     },
     "sansRomanBold": {
         "name": "sansRomanBold",
@@ -27,24 +27,24 @@
         "name": "sansRomanLight-num",
         "$type": "FontInfo",
         "family": "Sans_Roman_light_global_num",
-        "size": 10,
+        "size": 10
     },
     "sansRomanNormal_num": {
         "name": "sansRomanNormal-num",
         "$type": "FontInfo",
         "family": "Sans_Roman_normal_num",
-        "size": 10,
+        "size": 10
     },
     "sansRomanDemi_num": {
         "name": "sansRomanDemi-num",
         "$type": "FontInfo",
         "family": "Sans_Roman_demi_num",
-        "size": 10,
+        "size": 10
     },
     "sansRomanBold_num": {
         "name": "sansRomanBold-num",
         "$type": "FontInfo",
         "family": "Sans_Roman_bold_num",
-        "size": 10,
-    },
+        "size": 10
+    }
 }

--- a/example/main_qt6.qml
+++ b/example/main_qt6.qml
@@ -17,6 +17,7 @@ Window {
     property var model: [{"name": "config_1", "layer": null }, { "name": "config_2", "layer": null }, { "name": "config_3", "layer": null }]
 
     property QtObject config: _config.configData
+    property QtObject refConfig: _refConfig.configData
 
     JsonConfig {
         id: _config
@@ -47,6 +48,11 @@ Window {
         onActiveLayersChanged: {
             console.log("Active layers", activeLayers, configData.sansRomanLight50.family)
         }
+    }
+
+    JsonConfig {
+        id: _refConfig
+        filePath: ":/refconfig.json"
     }
 
     ColumnLayout {
@@ -127,8 +133,53 @@ Window {
                 rotation: config.editor.rotation
                 color: config.editor.colors.textDefaultColor
             }
-        }
 
+            Frame {
+                anchors.right: parent.right
+                anchors.top: parent.top
+                width: 200
+                height: 200
+
+                ColumnLayout {
+                    anchors.fill: parent
+
+                    Rectangle {
+                        id: _refBg
+                        Layout.fillHeight: true
+                        Layout.fillWidth: true
+                        color: refConfig.colors.window.background
+
+                        Button {
+                            id: refButton
+                            anchors.centerIn: _refBg
+                            text: 'JsonPointer'
+                            enabled: !checkBox.checked
+                            contentItem: Label {
+                                anchors.fill: parent
+                                text: refButton.text
+                                color: enabled ? refButton.hovered ? refConfig.colors.button.hoveredText : refConfig.colors.button.text : refConfig.colors.button.disabled
+
+                                horizontalAlignment: Text.AlignHCenter
+                                verticalAlignment: Text.AlignVCenter
+                                elide: Text.ElideRight
+                            }
+                            background: Rectangle {
+                                anchors.fill: parent
+                                radius: 2
+                                color: refConfig.colors.button.background
+                            }
+                        }
+                    }
+
+                    CheckBox {
+                        id: checkBox
+                        anchors.top: _refBg.bottom
+                        anchors.right: _refBg.right
+                        text: 'Disable Button'
+                    }
+                }
+            }
+        }
 
         ColumnLayout {
             Repeater {

--- a/example/qml.qrc
+++ b/example/qml.qrc
@@ -8,5 +8,6 @@
         <file>config_3.json</file>
         <file>fontconfig.json</file>
         <file>fontlayer.json</file>
+        <file>refconfig.json</file>
     </qresource>
 </RCC>

--- a/example/refconfig.json
+++ b/example/refconfig.json
@@ -1,0 +1,18 @@
+{
+	"palette": {
+		"accent": "#FFD100",
+		"light": "#5CD2FF",
+		"dark": "#004560"
+	},
+	"colors": {
+		"button": {
+			"background": { "$ref": "#/palette/light" },
+			"text": { "$ref": "#/colors/window/background" },
+			"hoveredText": { "$ref": "#/palette/accent" },
+			"disabled": "#A0A0A0"
+		},
+		"window": {
+			"background": { "$ref": "#/palette/dark" }
+		}
+	}
+}

--- a/src/private/node.h
+++ b/src/private/node.h
@@ -42,6 +42,7 @@ public:
         NamedMultiValue(QString key, QVariant value);
         QString key;
         QMap<int, QVariant> values;
+        QMap<int, QString> refs;
         bool emitPending = false;
         int userTypePropertyIndex = -1;
         QMetaObject::Connection listenerConnection;
@@ -49,6 +50,12 @@ public:
         int setValue(const QVariant &value);
         void writeValue(const QVariant &value, int level);
         void changePriority(int oldPrio, int newPrio);
+        bool isRef(int level) const;
+        const QString &ref() const;
+
+    private:
+        bool changeValuePriority(int oldPrio, int newPrio);
+        bool changeRefPriority(int oldPrio, int newPrio);
     };
 
     using NodePtr = QSharedPointer<Node>;
@@ -83,9 +90,15 @@ private:
     void createObject();
     void updateObjectProperties();
     static void emitSignalHelper(QObject *object, int signalIndex);
+    bool isRefObject(const QJsonObject &object) const;
+    QString getRefValue(const QJsonObject &object) const;
+    QString resolvedRefPath(const QString &ref) const;
+    QVariant resolvedRef(const QString &path) const;
+    QJsonObject refToJsonObject(const QString &ref) const;
 
     QObject *m_object = nullptr;
     Node *m_parent = nullptr;
+    Node *m_root = nullptr;
     QString m_name;
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     int typeHint = QMetaType::UnknownType;
@@ -94,6 +107,7 @@ private:
 #endif
     JsonConfig *m_config = nullptr;
     QList<NodePtr> m_childNodes;
+    QJsonObject *m_cachedJsonObject = nullptr;
     void handleSpecialProperty(const QString &name, const QString &value);
 };
 


### PR DESCRIPTION
Add support of Json pointers in config.
- Resolve a reference to json value
- Resolve chain of references
- Handle cyclic references
- References can be overlayed by simple values by next layer or vice versa
- Value can be updated from qml
- Handle config saving with references

Limitations:
- Reference to json object not supported
- Value can not be updated by reference from qml

Other:
- Fix fontconfig.json formating
- Add reference config example